### PR TITLE
[NAE-2293] Upgrade vulnerable and deprecated dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.netgrif</groupId>
     <artifactId>quartz-mongodb-connector</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <packaging>jar</packaging>
 
     <name>NETGRIF Quartz MongoDB</name>
@@ -69,13 +69,13 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.10</version>
+            <version>1.14</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.8</version>
+            <version>3.20.0</version>
         </dependency>
 
         <dependency>
@@ -93,7 +93,7 @@
         <dependency>
             <groupId>org.clojure</groupId>
             <artifactId>clojure</artifactId>
-            <version>1.10.0</version>
+            <version>1.11.2</version>
         </dependency>
 
         <!-- Test Dependencies -->


### PR DESCRIPTION
- Updated project version from `1.0.0` to `1.0.1` in `pom.xml`.
- Upgraded `commons-codec` dependency from `1.10` to `1.14`.
- Upgraded `commons-lang3` dependency from `3.8` to `3.20.0`.
- Upgraded `clojure` dependency from `1.10.0` to `1.11.2`.